### PR TITLE
Clean up compiler warnings

### DIFF
--- a/aprsis.c
+++ b/aprsis.c
@@ -18,6 +18,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <signal.h>
+#include <arpa/inet.h>
 
 #ifdef HAVE_NETINET_SCTP_H
 #include <netinet/sctp.h>

--- a/igate.c
+++ b/igate.c
@@ -501,8 +501,6 @@ void igate_from_aprsis(const char *ax25, int ax25len)
 	char  *headsbuf;
 	int    headscount = 0;
 //	char  *s;
-	char  *fromcall  = NULL;
-	char  *origtocall = NULL;
 
 	if (ax25[0] == '#') {  // Comment line, timer tick, something such...
           aprsis_commentframe(ax25, ax25len);
@@ -549,8 +547,6 @@ void igate_from_aprsis(const char *ax25, int ax25len)
 	  return;
 	}
 
-	fromcall   = heads[0];
-	origtocall = heads[1];
 	for (i = 0; i < headscount; ++i) {
 	  /* 3) */
 	  if (forbidden_to_gate_addr(heads[i])) {


### PR DESCRIPTION
Just a couple of those little silly ones, two unused variables and one missing #include. Something easy and relaxing to patch at this time of day.