### PR TITLE
Fix VERSION= in Makefile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -48,7 +48,7 @@ MANDIR:=$(strip $(MANDIR))
 
 # generate version strings
 
-VERSION	= $(shell git describe --tags | cut -b 2- || echo @VERSION_STRING@ | cut -b 2-)
+VERSION	= $(shell git describe --tags 2>/dev/null | cut -b 2- || echo @VERSION_STRING@ | cut -b 2-)
 
 DATE:=$(shell LC_ALL=C date --utc --date="$(SOURCE_DATE_EPOCH)" +"%Y %B %d")
 RFCDATE:=$(shell LC_ALL=C date --utc --date="$(SOURCE_DATE_EPOCH)" +"%a, %d %b %Y %H:%M:%S %z")

--- a/Makefile.in
+++ b/Makefile.in
@@ -48,7 +48,7 @@ MANDIR:=$(strip $(MANDIR))
 
 # generate version strings
 
-VERSION	= $(shell git describe --tags 2>/dev/null | cut -b 2- || echo @VERSION_STRING@ | cut -b 2-)
+VERSION	= $(shell (git describe --tags 2>/dev/null || echo @VERSION_STRING@) | cut -b 2-)
 
 DATE:=$(shell LC_ALL=C date --utc --date="$(SOURCE_DATE_EPOCH)" +"%Y %B %d")
 RFCDATE:=$(shell LC_ALL=C date --utc --date="$(SOURCE_DATE_EPOCH)" +"%a, %d %b %Y %H:%M:%S %z")


### PR DESCRIPTION
There were two general issues:

1.) When building `aprx` outside of a git repository, many of the following error were spit out:

`fatal: Not a git repository (or any of the parent directories): .git`

To address this, redirect stderr to /dev/null

2.) Besides that, VERSION_STRING was not actually being used if `git describe` failed. To address this, we re-arrange the order in which things are executed and add the extra set of parentheses so that `cut(1)` operates on the correct string for either case (fails without using `bash`)

Tested with: `zsh` (FreeBSD-CURRENT)
Tested with: `sh` (FreeBSD-CURRENT)
Tested with: `bash`  (Debian 4.8.11-1)