### PR TITLE
Detect FreeBSD, use FreeBSD date(1)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -48,7 +48,7 @@ MANDIR:=$(strip $(MANDIR))
 
 # generate version strings
 
-VERSION	= $(shell git describe --tags 2>/dev/null | cut -b 2- || echo @VERSION_STRING@ | cut -b 2-)
+VERSION	= $(shell (git describe --tags 2>/dev/null || echo @VERSION_STRING@) | cut -b 2-)
 
 DATE:=$(shell LC_ALL=C date --utc --date="$(SOURCE_DATE_EPOCH)" +"%Y %B %d")
 RFCDATE:=$(shell LC_ALL=C date --utc --date="$(SOURCE_DATE_EPOCH)" +"%a, %d %b %Y %H:%M:%S %z")

--- a/Makefile.in
+++ b/Makefile.in
@@ -45,13 +45,19 @@ VARLOG:=$(strip $(VARLOG))
 CFGFILE:=$(strip $(CFGFILE))
 SBINDIR:=$(strip $(SBINDIR))
 MANDIR:=$(strip $(MANDIR))
+UNAME:=$(shell uname)
 
 # generate version strings
 
 VERSION	= $(shell (git describe --tags 2>/dev/null || echo @VERSION_STRING@) | cut -b 2-)
 
+ifeq ($(UNAME), FreeBSD)
+DATE:=$(shell LC_ALL=C date -u -r "$(SOURCE_DATE_EPOCH)" +"%Y %B %d")
+RFCDATE:=$(shell LC_ALL=C date -u -r "$(SOURCE_DATE_EPOCH)" +"%a, %d %b %Y %H:%M:%S %z")
+else
 DATE:=$(shell LC_ALL=C date --utc --date="$(SOURCE_DATE_EPOCH)" +"%Y %B %d")
 RFCDATE:=$(shell LC_ALL=C date --utc --date="$(SOURCE_DATE_EPOCH)" +"%a, %d %b %Y %H:%M:%S %z")
+endif
 
 DEFS=	-DAPRXVERSION="\"$(VERSION)\"" \
 	-DVARRUN="\"$(VARRUN)\"" -DVARLOG="\"$(VARLOG)\"" \


### PR DESCRIPTION
Apologies for missing this in my initial pass -- FreeBSD's `date(1)` is not compatible, argument-wise. We can test `uname` as a fairly primitive check to vaguely see if we're on a FreeBSD system and use the appropriate `date(1)` arguments, falling back to the otherwise expected GNU/Linux assumption otherwise.

This is the last nit I have with build system foo, I'll move on to actually launching `aprx` and figuring out if there are any kinks remaining. A cursory glance at the pretty awesome documentation and serial-handling bits leads me to believe there's probably not much further work needed for FreeBSD bring-up. The only `/dev` assumption seems to be the reasonable `/dev/null exists` assumption, and everything else looks pretty configurable.