### PR TITLE
Removed source code comments with unoptimal TODO/FIXME items

### DIFF
--- a/igate.c
+++ b/igate.c
@@ -312,25 +312,18 @@ void igate_to_aprsis(const char *portname, const int tncid, const char *tnc2buf,
 		goto redo_frame_filter;
 	}
 
-
-
-	/* TODO: Verify message being of recognized APRS packet type */
-	/*   '\0x60', '\0x27':  MIC-E, len >= 9
-	 *   '!','=','/','{':   Normal or compressed location packet..
-	 *   '$':               NMEA data, if it begins as '$GP'
-	 *   '$':               WX data (maybe) if not NMEA data
-	 *   ';':               Object data, len >= 31
-	 *   ')':               Item data, len >= 18
-	 *   ':':               message, bulletin or aanouncement, len >= 11
-	 *   '<':               Station Capabilities, len >= 2
-	 *   '>':               Status report
-	 *   '}':               Third-party message
-	 * ...  and many more ...
+	/* At this point, the packet is good for igating. The receiving igate
+	 * must not perform duplicate filtering, since the APRS-IS server
+	 * may well use those duplicates for something, such as propagation
+	 * analysis or smarter message routing. The APRS-IS server will do
+	 * duplicate filtering just fine.
+	 *
+	 * The receiving igate should also not validate or limit the packet
+	 * format/contents either, because that would impose limits on
+	 * future packet formats, experiments and improvements. The
+	 * packet's sender and recipient should agree on the format only.
 	 */
-
-	// FIXME: Duplicate filter messages to APRSIS
 	
-
 	/* _NO_ ending CRLF, the APRSIS subsystem adds it. */
 
 	/*

--- a/kiss.c
+++ b/kiss.c
@@ -430,8 +430,8 @@ static int kissprocess(struct serialport *S)
 	   S->rdline[1..S->rdlinelen-1]
 	   */
 
-	/* Send the frame to APRS-IS, return 1 if valid AX.25 UI message, does not
-	   validate against valid APRS message rules... (TODO: it could do that too) */
+	/* Send the frame to APRS-IS, return 1 if valid AX.25 UI message, must not
+	   validate against valid APRS message rules; not igate's job to judge */
 
 	// The AX25_TO_TNC2 does validate the AX.25 packet,
 	// converts it to "TNC2 monitor format" and sends it to


### PR DESCRIPTION
RX iGate should not drop removed duplicates or filter packets it deems incorrect by content, as that is error-prone and hides broken packets in a way that no-one can diagnose them. The recipient on the APRS-IS can decode, ignore or report bad packets.

Removed source code comments which suggested doing so.