### PR TITLE
Fix spelling errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -540,7 +540,7 @@
 2012-12-09 Matt Maguire VK2RQ <matt.vk2rq@gmail.com>
 
 	* telemetry.c:
-	    Sometimes the Erlang registery contains interface
+	    Sometimes the Erlang registry contains interface
 	    entries that are no longer actually in the system.
 	    Avoid NULL referral at such situations.
 
@@ -916,7 +916,7 @@
 	* filter.c:
 	    Negative ranges on filters means "outside the distance".
 	    This allows adding "substractive" filters that tell
-	    "don't pass messages to receipients outside given range".
+	    "don't pass messages to recipients outside given range".
 
 	* configure.in, interface.c, cellmalloc.c, timestamp.c,
 	  kiss.c, historydb.h, netax25.c, pbuf.h, aprx.c, aprx.h,
@@ -1230,7 +1230,7 @@
 	    TNC2 format address formats.
 
 	* parse_aprs.c:
-	    Remove unnecessary double precission floating point math.
+	    Remove unnecessary double precision floating point math.
 	    Use of 'float' is quite enough.
 
 	* debian/control:
@@ -1741,7 +1741,7 @@
 2009-10-21  Matti Aarnio - OH2MQK - KP20NG  <oh2mqk@sral.fi>
 
 	* config.c:
-	    Clean away some superflous debugs.
+	    Clean away some superfluous debugs.
 
 	* digipeater.c:
 	    Viscous mode debug printout crashes on SEGV.. Oops.
@@ -1995,7 +1995,7 @@
 
 	* ttyreader.c:
 	    Fix on serial port startup - always turn on flows on
-	    the port, and explicitely flush the driver level
+	    the port, and explicitly flush the driver level
 	    buffers discarding possibly accumulated data.
 
 2009-09-28  Matti Aarnio - OH2MQK - KP20NG  <oh2mqk@sral.fi>
@@ -2105,7 +2105,7 @@
 	    parameter.  There is no longer a wild-card receiving
 	    mode in Linux internal AX.25 network receiving.
 	    All APRS receiving interface callsigns must be listed
-	    explicitely.
+	    explicitly.
 
 	* netax25.c, ttyreader.c, aprx.h:
 	    SMACK probe transmits on link that is configured for it.
@@ -2130,7 +2130,7 @@
 	    the use of new IP resolver API a bit.
 
 	* ttyreader.c:
-	    Explicitely set "KISSSTATE_SYNCHUNT = 0" in enumeration.
+	    Explicitly set "KISSSTATE_SYNCHUNT = 0" in enumeration.
 	    Memory blocks are created with memset() call clearing them.
 
 	* aprx.h, beacon.c:
@@ -2251,7 +2251,7 @@
 	    and usage codes -- pass a struct block as message leader.
 
 	* ttyreader.c, netax25.c, aprsis, ax25.c, beacon.c, aprx.h:
-	    Pass explicite parameter towards the APRSIS telling, which
+	    Pass explicit parameter towards the APRSIS telling, which
 	    callsign (radio receiver) the message came in from.
 
 	* aprx.h, config.c, ttyreader.c, beacon.c:
@@ -2480,7 +2480,7 @@
 	    Now initstring, and various KISS modes are configurable
 
 	* erlang.c:
-	    Carefull approach on erlang-file opening, if file exists,
+	    Careful approach on erlang-file opening, if file exists,
 	    and is non-zero size, open it only if magics match.
 
 	* config.c:
@@ -2537,7 +2537,7 @@
 2007-12-06  Matti Aarnio - OH2MQK - KP20NG  <oh2mqk@sral.fi>
 
 	* aprsg.8, erlang.c, aprsg.c, netax25.c, ttyreader.c:
-	    Erlang logging now uses syslog(3), unless explicitely told to use
+	    Erlang logging now uses syslog(3), unless explicitly told to use
 	    output to stdout.  Also the Erlang log format was altered a bit,
 	    now it reports also number of packets in the interval.
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -216,5 +216,5 @@ make-rpm: # actually just a reminder of how to do it..
 
 # -------------------------------------------------------------------- #
 
-# include object depencies if available
+# include object dependencies if available
 -include $(OBJS:.o=.d)

--- a/PROTOCOLS
+++ b/PROTOCOLS
@@ -44,7 +44,7 @@ APRS-IS interchange
 	something that the server replies..)
 
 
-	After successfull login, communication carries "TNC2" format
+	After successful login, communication carries "TNC2" format
 	APRS messages.  Namely text encoding of AX.25 UI frames in
 	what became known as "TNC2 monitor style":
 

--- a/TIMESTAMP-AT-APRSIS
+++ b/TIMESTAMP-AT-APRSIS
@@ -162,7 +162,7 @@ Example UNIX system C code to produce and encode a timestamp:
   //
   // The NTP timebase is 00:00 Jan 1 1900.  The local
   // time base is 00:00 Jan 1 1970.  Convert between
-  // these two by added or substracting 70 years
+  // these two by added or subtracting 70 years
   // worth of time.  Note that 17 of these years were
   // leap years.
   

--- a/TODO
+++ b/TODO
@@ -90,7 +90,7 @@
   the network delays have been excessive and message is discarded.
 
   This SNTP client _does_ _not_ adjust host system clock, only tracks
-  difference of it against a high(er)-quality NTP service elsewere.
+  difference of it against a high(er)-quality NTP service elsewhere.
   The difference and drift parameters are used to convert current system
   gettimeofday() result to NTP timestamp within the code, and to determine
   how old something is, a NTP timestamp is compared against "current time."
@@ -120,7 +120,7 @@ BoB:
 		"176RX, 109TX, 243 busy"
 
 	ON a ten minute basis (total 600 1 sec slots) this tells us that
-	176 packets were decoded at this site, 109 were elegible for
+	176 packets were decoded at this site, 109 were eligible for
 	further digipeating, and another 243 seconds the channel was
 	busy with other collisions and non decodable traffic.  Leaving
 	72 secnds the channel was clear.

--- a/agwpesocket.c
+++ b/agwpesocket.c
@@ -75,7 +75,7 @@
 
 // ASK To start receiving AX25 RAW Frames
 //
-// Sending again thos command will disable this service.
+// Sending again this command will disable this service.
 // You can start and stop this service any times you needed
 //
 // Port field no needed set it to 0
@@ -138,7 +138,7 @@
 // [port][DataKind][CallFrom][CallTo ][DataLen][USER][Data         ]
 //  4bytes  4bytes     10bytes  10bytes   4bytes     4bytes    DataLen Bytes
 // the data field format is as follow in plain text
-// howmany ports ;1st radioport description;2nd radioport;....;last radioport describtion
+// howmany ports ;1st radioport description;2nd radioport;....;last radioport description
 // like
 // 2;TNC2 on serialport 1;OE5DXL on serialport2;
 // We have here 2 radioports. The separator is the ';'
@@ -152,7 +152,7 @@
 // CallTo is empty(NULL)
 // DataLen =The number of bytes of DATA field
 // USER is undefined
-// DATA field conatins the radioport description
+// DATA field contains the radioport description
 // [ HEADER                                   ]
 // [port][DataKind][CallFrom][CallTo ][DataLen][USER] [DATA]
 //  4bytes  4bytes     10bytes  10bytes   4bytes     4bytes    Datalen bytes.

--- a/aprsis.c
+++ b/aprsis.c
@@ -614,7 +614,7 @@ int aprsis_queue(
 											   slow reconnection. */
 
 	return (i != len);
-	/* Return 0 if ANY of the queue operations was successfull
+	/* Return 0 if ANY of the queue operations was successful
 	   Return 1 if there was some error.. */
 }
 
@@ -921,7 +921,7 @@ static void aprsis_runthread(void) {
 	sigaddset(&sigs_to_block, SIGUSR1);
 	pthread_sigmask(SIG_BLOCK, &sigs_to_block, NULL);
 
-	// generally the cancelability is enabled
+	// generally the cancellability is enabled
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 
 	if (debug) printf("aprsis_runthread()\n");

--- a/aprx-complex.conf.in
+++ b/aprx-complex.conf.in
@@ -376,7 +376,7 @@ aprxlog @VARLOG@/aprx.log
 # Aprx configuration parser.  If you want a '\' on APRS content,
 # then you encode it on configuration file as:  '\\'
 #
-# Stranger combinations with explicite "transmit this to interface X":
+# Stranger combinations with explicit "transmit this to interface X":
 #
 #
 #beacon                     file /tmp/wxbeacon.txt

--- a/aprx.8.in
+++ b/aprx.8.in
@@ -128,7 +128,7 @@ every kind of frame received in KISS variants.
 .I "Erlang output"
 prints 10 minute and 60 minute traffic accumulation byte counts, and guestimates
 on channel occupancy, alias "Erlang".
-These outputs are sent to STDOUT, which system operator may choose to log elsewere.
+These outputs are sent to STDOUT, which system operator may choose to log elsewhere.
 This is independent if the "\-l" option below.
 .TP
 .BI "\-f " "@CFGFILE@"
@@ -1198,7 +1198,7 @@ The
 .B viscous\-delay
 defines a number of seconds from 0 (default) maximum of 9 that
 the source will put the message on duplicate detector delay processing.
-All occurrances of same packet per duplicate detector during that time
+All occurrences of same packet per duplicate detector during that time
 will be accounted on duplicate detection, and if at the end of the delay
 period there are more than one hit, the packet is discarded.
 Use delay of 0 seconds for normal digipeater, 5 seconds for a fill-in,
@@ -1384,13 +1384,13 @@ The
 .IR Erlang -monitor
 mechanisms are of rudimentary quality, and can seriously underestimate
 the channel occupancy by ignoring pre- and postample transmissions,
-which can be as high as 50 centiseconds for preample, and 20 centiseconds
+which can be as high as 50 centiseconds for preamble, and 20 centiseconds
 for postample!
-When entire packet takes 50 centiseconds, such preample alone doubles channel
+When entire packet takes 50 centiseconds, such preamble alone doubles channel
 occupancy.
 A 6pack protocol on serial link (instead of KISS) could inform receiver
-better on carrier presense times, however even that underestimates RF power
-presense (RSSI) signal.  (6pack is not supported.)
+better on carrier presence times, however even that underestimates RF power
+presence (RSSI) signal.  (6pack is not supported.)
 .PP
 On serial lines supports really only 8n1 mode, not at all like: 7e1.
 On the other hand, there really is no sensible usage for anything but 8n1...

--- a/aprx.conf.in
+++ b/aprx.conf.in
@@ -296,7 +296,7 @@ aprxlog @VARLOG@/aprx.log
 # Aprx configuration parser.  If you want a '\' on APRS content,
 # then you encode it on configuration file as:  '\\'
 #
-# Stranger combinations with explicite "transmit this to interface X":
+# Stranger combinations with explicit "transmit this to interface X":
 #
 #beacon                     file /tmp/wxbeacon.txt
 #beacon interface N0CALL-3 srccall N0CALL-3 \

--- a/aprx.h
+++ b/aprx.h
@@ -106,7 +106,7 @@ extern void   *memrchr(const void *s, int c, size_t n);
 #include <netdb.h>
 #include <netinet/in.h>
 
-/* Radio interface groups on igate receiption history tracking.
+/* Radio interface groups on igate reception history tracking.
  * Value range:  1 to MAX_IF_GROUP-1.
  * Value 0 is reserved for APRSIS.
  */

--- a/aprxpolls.c
+++ b/aprxpolls.c
@@ -12,7 +12,7 @@
 #include "aprx.h"
 
 
-/* aprxpolls libary functions.. */
+/* aprxpolls library functions.. */
 
 
 void aprxpolls_reset(struct aprxpolls *app)

--- a/beacon.c
+++ b/beacon.c
@@ -961,7 +961,7 @@ static void beacon_it(struct beaconset *bset, struct beaconmsg *bm)
 			syslog(LOG_ERR, "Failed to exec file %s", bm->execfile);
 			return;
 		}
-                return; // spawning done, successfull or not..
+                return; // spawning done, successful or not..
 	} else {
           if (debug>1) printf("Nothing to beacon now.\n");
           return;

--- a/cellmalloc.c
+++ b/cellmalloc.c
@@ -55,7 +55,7 @@ struct cellarena_t {
 #ifdef MEMDEBUG
 	int	 cellblocks_count;
 #define CELLBLOCKS_MAX 40 /* track client cell allocator limit! */
-	char	*cellblocks[CELLBLOCKS_MAX];	/* ref as 'char pointer' for pointer arithmetics... */
+	char	*cellblocks[CELLBLOCKS_MAX];	/* ref as 'char pointer' for pointer arithmetic... */
 #endif
 };
 
@@ -122,7 +122,7 @@ int new_cellblock(cellarena_t *ca)
 #endif
 
 	for (i = 0; i <= ca->createsize-ca->increment; i += ca->increment) {
-		struct cellhead *ch = (struct cellhead *)(cb + i); /* pointer arithmentic! */
+		struct cellhead *ch = (struct cellhead *)(cb + i); /* pointer arithmetic! */
 		if (!ca->free_head) {
 		  ca->free_head = ch;
 		} else {

--- a/config.c
+++ b/config.c
@@ -215,7 +215,7 @@ static int logging_config(struct configfile *cf) {
 			continue;	/* Comment line, or empty line */
 
 		str = cf->buf;
-		str = config_SKIPSPACE(str); // arbitrary indention
+		str = config_SKIPSPACE(str); // arbitrary indentation
 		name = str;
 		str = config_SKIPTEXT(str, NULL);
 		str = config_SKIPSPACE(str);
@@ -299,7 +299,7 @@ static int cfgparam(struct configfile *cf) {
 	char *name, *param1;
 	char *str = cf->buf;
 
-	str = config_SKIPSPACE(str); // arbitrary indention
+	str = config_SKIPSPACE(str); // arbitrary indentation
 	name = str;
 	str = config_SKIPTEXT(str, NULL);
 	str = config_SKIPSPACE(str);

--- a/digipeater.c
+++ b/digipeater.c
@@ -1484,7 +1484,7 @@ static void digipeater_receive_backend(struct digipeater_source *src, struct pbu
 
 			if (sizeof(tbuf) > t2l + pb->ax25datalen && t2l > 0) {
 				// Have space for body too, skip leading Ctrl+PID bytes
-				memcpy(tbuf+t2l, pb->ax25data+2, pb->ax25datalen-2); // Ctrl+PID skiped
+				memcpy(tbuf+t2l, pb->ax25data+2, pb->ax25datalen-2); // Ctrl+PID skipped
 				t2l2 = t2l + pb->ax25datalen-2; // tbuf size sans Ctrl+PID
 
 				rflog( digi->transmitter->callsign, 'T', 0, tbuf, t2l2 );

--- a/dprsgw.c
+++ b/dprsgw.c
@@ -593,7 +593,7 @@ static void dprsgw_nmea_igate( const struct aprx_interface *aif,
 	  p = p2+7;
 	}
 	while (p2+7 > p) { // Too short!
-	  *p++ = ' '; // unprecise position
+	  *p++ = ' '; // imprecise position
 	}
 	if (gga[2] != NULL) {
 	  s = gga[3]; // <N|S>
@@ -624,7 +624,7 @@ static void dprsgw_nmea_igate( const struct aprx_interface *aif,
 	  p = p2+8;
 	}
 	while (p2+8 > p) { // Too short!
-	  *p++ = ' '; // unprecise position
+	  *p++ = ' '; // imprecise position
 	}
 	if (gga[2] != NULL) {
 	  p += sprintf(p, "%s", gga[5]); // <E|W>

--- a/erlang.c
+++ b/erlang.c
@@ -233,7 +233,7 @@ static int erlang_backingstore_grow(int do_create, int add_count)
 			goto redo_open;	/* redo mapping */
 		}
 
-		/* Ok, successfull open, correct linecount */
+		/* Ok, successful open, correct linecount */
 		ErlangLines =
 			(void *) realloc((void *) ErlangLines,
 					 (ErlangLinesCount +
@@ -263,7 +263,7 @@ static int erlang_backingstore_grow(int do_create, int add_count)
 	EF = erlang_mmap;
 	ErlangHead = &EF->head;
 
-	/* Ok, successfull open, correct linecount */
+	/* Ok, successful open, correct linecount */
 	ErlangLines =
 		(void *) realloc((void *) ErlangLines,
 				 (ErlangLinesCount + 1) * sizeof(void *));

--- a/filter.c
+++ b/filter.c
@@ -36,7 +36,7 @@
   m/dist  		My Range filter
   o/obj1/obj2...  	Object filter (*)
   p/aa/bb/cc...  	Prefix filter
-  q/con/ana 	 	q Contruct filter
+  q/con/ana 	 	q Construct filter
   r/lat/lon/dist  	Range filter
   s/pri/alt/over  	Symbol filter
   t/poimntqsu3*c	Type filter
@@ -67,7 +67,7 @@
 
   Undocumented at above web-page, but apparent behaviour is:
 
-  - Everything not explicitely stated to be case sensitive is
+  - Everything not explicitly stated to be case sensitive is
     case INSENSITIVE
 
   - Minus-prefixes on filters behave as is there are two sets of
@@ -1215,7 +1215,7 @@ int filter_parse(struct filter_t **ffp, const char *filt)
 #if 0
 	case 'q':
 	case 'Q':
-		/* q/con/ana           q Contruct filter */
+		/* q/con/ana           q Construct filter */
 		s = filt+1;
 		f0.h.type = 'q';
 		f0.h.u4.bitflags = 0; /* For QC_*  flags */
@@ -1895,7 +1895,7 @@ static int filter_process_one_p(struct pbuf_t *pb, struct filter_t *f)
 #if 0
 static int filter_process_one_q(struct pbuf_t *pb, struct filter_t *f)
 {
-	/* q/con/ana  	q Contruct filter
+	/* q/con/ana  	q Construct filter
 
 	   q = q Construct command
 	   con = list of q Construct to pass (case sensitive)

--- a/historydb.c
+++ b/historydb.c
@@ -256,7 +256,7 @@ history_cell_t *historydb_insert_(historydb_t *db, const struct pbuf_t *pb, cons
 	cp = cp1 = NULL;
 	hp = &db->hash[i];
 
-	// scan the hash-bucket chain, and do incidential obsolete data discard
+	// scan the hash-bucket chain, and do incidental obsolete data discard
 	while (( cp = *hp )) {
 		if (timecmp(cp->arrivaltime, expirytime) < 0) {
 			// OLD...
@@ -424,7 +424,7 @@ history_cell_t *historydb_insert_heard(historydb_t *db, const struct pbuf_t *pb)
 	cp1 = NULL;
 	hp = &db->hash[i];
 
-	// scan the hash-bucket chain, and do incidential obsolete data discard
+	// scan the hash-bucket chain, and do incidental obsolete data discard
 	while (( cp = *hp ) != NULL) {
         	if (timecmp(cp->arrivaltime, expirytime) < 0) {
 			// OLD...

--- a/historydb.h
+++ b/historydb.h
@@ -16,7 +16,7 @@
  *	Keying varies, origination callsign of positions, name
  *	for object/item.
  *
- *	Inserting does incidential cleanup scanning while traversing
+ *	Inserting does incidental cleanup scanning while traversing
  *	hash chains.
  *
  *	In APRS-IS there are about 25 000 distinct callsigns or

--- a/igate.c
+++ b/igate.c
@@ -155,7 +155,7 @@ void verblog(const char *portname, int istx, const char *tnc2buf, int tnc2len) {
 
 /*
  * The  tnc2_rxgate()  is actual RX I-gate filter function, and processes
- * prepated TNC2 format text presentation of the packet.
+ * prepared TNC2 format text presentation of the packet.
  * It does presume that the record is in a buffer that can be written on!
  */
 

--- a/igate.c
+++ b/igate.c
@@ -254,7 +254,7 @@ redo_frame_filter:;
 		goto discard;
 	}
 
-	/* Messages begining with '}' char are 3rd-party frames.. */
+	/* Messages beginning with '}' char are 3rd-party frames.. */
 	if (*t == '}') {
 		/* DEBUG OUTPUT TO STDOUT ! */
 		verblog(portname, 0, tp, tnc2len);
@@ -264,7 +264,7 @@ redo_frame_filter:;
 		rflog(portname, 'd', discard, tp, tnc2len);
 
 		strictax25 = 0;
-		/* Copy the 3rd-party message content into begining of the buffer... */
+		/* Copy the 3rd-party message content into beginning of the buffer... */
 		++t;				/* Skip the '}'		*/
 		tp = t;
 		tnc2len = e - t;		/* New length		*/
@@ -338,7 +338,7 @@ static int forbidden_to_gate_addr(const char *s)
 
 /*
  * For APRSIS -> Aprx -> RF gatewaying.
- * Have to convert incoming TNC2 format messge to AX.25..
+ * Have to convert incoming TNC2 format message to AX.25..
  *
  * See:  http://www.aprs-is.net/IGateDetails.aspx
  *

--- a/keyhash.c
+++ b/keyhash.c
@@ -10,7 +10,7 @@
 /*
  * Keyhash routines for the system.
  *
- * What is needed is _fast_ hash function.  Preferrably arithmethic one,
+ * What is needed is _fast_ hash function.  Preferably arithmetic one,
  * which does not need table lookups, and can work with aligned 32 bit
  * data -- but also on unaligned, and on any byte counts...
  *

--- a/kiss.c
+++ b/kiss.c
@@ -372,7 +372,7 @@ static int kissprocess(struct serialport *S)
 
 					memcpy(S->wrbuf + S->wrlen, kissbuf, kisslen);
 					S->wrlen += kisslen;
-					/* Flush it out..  and if not successfull,
+					/* Flush it out..  and if not successful,
 					   poll(2) will take care of it soon enough.. */
 					ttyreader_linewrite(S);
 
@@ -538,7 +538,7 @@ int kiss_pullkiss(struct serialport *S)
 					S->rdlinelen = 0;
 				}
 
-				/* rdlinelen == 0 because we are receiving consequtive
+				/* rdlinelen == 0 because we are receiving consecutive
 				   FENDs, or just processed our previous frame.  Treat
 				   them the same: discard this byte. */
 
@@ -726,7 +726,7 @@ void kiss_poll(struct serialport *S)
           
 	        	memcpy(S->wrbuf + S->wrlen, kissbuf, kisslen);
                         S->wrlen += kisslen;
-                        /* Flush it out..  and if not successfull,
+                        /* Flush it out..  and if not successful,
                            poll(2) will take care of it soon enough.. */
                         ttyreader_linewrite(S);
           

--- a/netax25.c
+++ b/netax25.c
@@ -439,7 +439,7 @@ void *netax25_addrxport(const char *callsign, const struct aprx_interface *inter
 	    return NULL;
 	  }
 	  nax25p->callsign  = strdup(callsign);
-	} else {  // new config fule
+	} else {  // new config file
 	  memcpy(&nax25p->ax25addr.sax25_call, interface->ax25call, sizeof(interface->ax25call));
 	  nax25p->callsign  = interface->callsign;
 	}

--- a/parse_aprs.c
+++ b/parse_aprs.c
@@ -334,7 +334,7 @@ static int parse_aprs_nmea(struct pbuf_t *pb, const char *body, const char *body
 	   $GPRMC  Remommended Minimum Specific GPS/Transit Data
 	   $GPWPT  Way Point Location ?? (bug in APRS specs ?)
 	   $GPWPL  Waypoint Load (not in APRS specs, but in NMEA specs)
-	   $PNTS   Seen on APRS-IS, private sentense based on NMEA..
+	   $PNTS   Seen on APRS-IS, private sentence based on NMEA..
 	   $xxTLL  Not seen on radio network, usually $RATLL - Target positions
 	           reported by RAdar.
 	 */

--- a/telemetry.c
+++ b/telemetry.c
@@ -399,7 +399,7 @@ static void telemetry_labeltx()
 
 /*
  * Transmit telemetry to the RF interface that is being monitored.
- * Interface 'flags' contain controls on thist.
+ * Interface 'flags' contain controls on this.
  */
 static void rf_telemetry(const struct aprx_interface *sourceaif,
 		const char *beaconaddr,

--- a/timestamp.c
+++ b/timestamp.c
@@ -4,7 +4,7 @@
  *
  * The NTP timebase is 00:00 Jan 1 1900.  The local
  * time base is 00:00 Jan 1 1970.  Convert between
- * these two by added or substracting 70 years
+ * these two by added or subtracting 70 years
  * worth of time.  Note that 17 of these years were
  * leap years.
  */

--- a/ttyreader.c
+++ b/ttyreader.c
@@ -438,7 +438,7 @@ static void ttyreader_linesetup(struct serialport *S)
 		  }
 		}
 
-		/* Flush it out..  and if not successfull,
+		/* Flush it out..  and if not successful,
 		   poll(2) will take care of it soon enough.. */
 		ttyreader_linewrite(S);
 


### PR DESCRIPTION
I'm not sure that fixing the old entries of the changelog is the right thing to do.

Fixed with:
codespell --ignore-words-list=hist,parm,seting,statics,tread --write-changes --interactive=2