### PR TITLE
Update pthread stack size to work around NetBSD bug

### DIFF
--- a/aprsis.c
+++ b/aprsis.c
@@ -952,7 +952,7 @@ void aprsis_start(void) {
 	if (debug) printf("aprsis_start() PTHREAD  socketpair(up=%d,down=%d)\n", aprsis_up, aprsis_down);
 
 	pthread_attr_init(&pthr_attrs);
-	/* 64 kB stack is enough for this thread (I hope!)
+	/* 78 kB stack is enough for this thread (I hope!)
 	   default of 2 MB is way too much...*/
 	pthread_attr_setstacksize(&pthr_attrs, 78*1024);
 

--- a/aprsis.c
+++ b/aprsis.c
@@ -954,7 +954,7 @@ void aprsis_start(void) {
 	pthread_attr_init(&pthr_attrs);
 	/* 64 kB stack is enough for this thread (I hope!)
 	   default of 2 MB is way too much...*/
-	pthread_attr_setstacksize(&pthr_attrs, 64*1024);
+	pthread_attr_setstacksize(&pthr_attrs, 78*1024);
 
 	i = pthread_create(&aprsis_thread, &pthr_attrs, (void*)aprsis_runthread, NULL);
 	if (i == 0) {


### PR DESCRIPTION
On NetBSD (i386, other architectures untested), the program segfaults in when getaddrinfo() is called from a thread with a small stack size:

[https://mail-index.netbsd.org/tech-userlevel/2021/11/28/msg013174.html](https://mail-index.netbsd.org/tech-userlevel/2021/11/28/msg013174.html)

I've tweaked the pthread_attr_setstacksize() up a bit to prevent this.